### PR TITLE
:bug: Fix: 메인페이지의 최신 모집글의 요청 api 변경

### DIFF
--- a/src/components/MainPage/RecentRecruitCardList.jsx
+++ b/src/components/MainPage/RecentRecruitCardList.jsx
@@ -7,7 +7,7 @@ function RecentRecruitCardList()  {
   useEffect(() => {
     const fetchRecruitData = async () => {
         try {
-            const response = await fetch(`${baseURL}/recruits/hot/`);
+            const response = await fetch(`${baseURL}/recruits/recent/`);
             if (!response.ok) {
                 throw new Error('Failed to fetch book data');
             }

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -18,8 +18,7 @@ function MainPage() {
           <div className="w-full max-w-screen mx-auto rounded-lg overflow-hidden relative">
           <h2 className="font-bold text-black px-4 mt-2 mb-0 flex items-center md:px-0 md:mb-0 w-full">
           {/*타이틀*/}
-          <div className='flex justify-between w-full'>
-            <Margin left="3"></Margin>
+          <div className='flex w-full'>
           <span className="font-bold w-32">신간 도서</span>  
           </div>
           </h2>


### PR DESCRIPTION
## 수정한파일
src\pages\MainPage.jsx
src\components\MainPage\RecentRecruitCardList.jsc

## 수정한 원인
최신 모집글이 BE의 hot_list(화제의 모집글)을 요청하고 있었습니다. 최신 모집글 요청 api로 갈음합니다.

## 비고
추가로, 신간도서의 소제목이 우측정렬되어있던 것을 좌측으로 변경하였습니다.