### PR TITLE
✨ Feat : 커스텀 axios를 이용한 인터셉터 에러 핸들링 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,12 +22,16 @@ import TeamDetailPage from './pages/TeamDetailPage.jsx';
 import ProfileEditPage from './pages/ProfileEditPage.jsx';
 import Chatting from './pages/Chatting.jsx';
 import RecruitPostEditPage from './pages/RecruitPostEditPage.jsx';
+import Error500 from './components/Error/Error500Page.jsx';
+import Error404 from './components/Error/Error404Page.jsx';
 
 import Footer from "./components/Footer.jsx";
 import Navbar from "./components/Navbar.jsx";
 import LeftMenu from "./components/LeftMenu.jsx"; // Import LeftMenu component
 import LeftMenu2 from "./components/LeftMenu2.jsx";
 import LeftMenu3 from "./components/LeftMenu3.jsx";
+import Error404Page from "./components/Error/Error404Page.jsx";
+import Error500Page from "./components/Error/Error500Page.jsx";
 
 
 
@@ -126,6 +130,12 @@ const pages = [
   // 채팅쪽은 확인 필요합니다.
   // 채팅페이지
   { path: "/chatroom/:room_id/", component: Chatting, layoutType: "Non" },
+
+  // 에러 페이지
+  { path: "/error/404/", component: Error404Page, layoutType: "Non" },
+  { path: "/error/500/", component: Error500Page, layoutType: "Non" },
+  
+
   
 ];
 

--- a/src/api/applyRecruit.js
+++ b/src/api/applyRecruit.js
@@ -1,5 +1,5 @@
 // api.js
-
+import {httpClient} from './interceptor';
 import axios from 'axios';
 
 const user = JSON.parse(localStorage.getItem("user"));
@@ -7,7 +7,7 @@ const accessToken = user?.access_token || "";
 const baseURL = import.meta.env.VITE_APP_API_KEY;
 
 
-const axiosInstance = axios.create({
+const axiosInstance = httpClient.create({
   baseURL: baseURL,  // Replace with your API base URL
   headers: {
     Authorization: `Bearer ${accessToken}`,
@@ -16,7 +16,7 @@ const axiosInstance = axios.create({
 
 export const applyForRecruit = async (recruitId) => {
   try {
-    const response = await axiosInstance.post(`/recruits/${recruitId}/apply/`);
+    const response = await httpClient.post(`/recruits/${recruitId}/apply/`);
     return response.data;
   } catch (error) {
     console.error('Error applying for recruit:', error);
@@ -26,7 +26,7 @@ export const applyForRecruit = async (recruitId) => {
 
 export const cancelRecruitApplication = async (recruitId) => {
   try {
-    const response = await axiosInstance.delete(`/recruits/${recruitId}/apply/`);
+    const response = await httpClient.delete(`/recruits/${recruitId}/apply/`);
     return response.data;
   } catch (error) {
     console.error('Error canceling recruit application:', error);
@@ -36,7 +36,7 @@ export const cancelRecruitApplication = async (recruitId) => {
 
 export const checkRecruitApplication = async (recruitId) => {
   try {
-    const response = await axiosInstance.get(`/recruits/${recruitId}/apply/`);
+    const response = await httpClient.get(`/recruits/${recruitId}/apply/`);
     return response.data;
   } catch (error) {
     console.error('Error checking recruit application:', error);

--- a/src/api/comment.js
+++ b/src/api/comment.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 const baseURL = import.meta.env.VITE_APP_API_KEY;
+import {httpClient} from './interceptor';
 
 
 export const FetchAllCommentsData = async ({id,page=1}) => {
@@ -11,7 +12,7 @@ export const FetchAllCommentsData = async ({id,page=1}) => {
             return null;
         }
      
-        const res = await axios.get(`${baseURL}/comments/?post_id=${id}&page=${page}`, {
+        const res = await httpClient.get(`${baseURL}/comments/?post_id=${id}&page=${page}`, {
             headers: {
                 Authorization: `Bearer ${accessToken}`,
             },
@@ -36,7 +37,7 @@ export const FetchAllReqCommentsData = async ({id,page=1}) => {
             return null;
         }
     
-        const res = await axios.get(`${baseURL}/comments/?recruits=${id}&page=${page}`, {
+        const res = await httpClient.get(`${baseURL}/comments/?recruits=${id}&page=${page}`, {
             headers: {
                 Authorization: `Bearer ${accessToken}`,
             },
@@ -65,7 +66,7 @@ export const FetchCreateComments = async ({ post_id, recruits, content, to_user 
       // post_id를 숫자로 변환
       const numericPostId = Number(post_id);
       const numericRecuritId= Number(recruits);
-      const res = await axios.post(`${baseURL}/comments/`, {
+      const res = await httpClient.post(`${baseURL}/comments/`, {
         "post_id": numericPostId,
         "recruits": numericRecuritId,  // recruits가 이미 숫자라면 변환 필요 없음
         "content": content,

--- a/src/api/interceptor.js
+++ b/src/api/interceptor.js
@@ -10,12 +10,11 @@ httpClient.interceptors.response.use(
   },
   async error => {
     if (error.response && error.response.status === 401) {
-      // 401 응답일 때만 토큰 갱신
+      // 401 응답일 때 토큰 갱신
       try {
         const newTokenData = await AutoRefreshToken();
         // 갱신된 토큰으로만 업데이트
         if (newTokenData.access_token) {
-          console.log(newTokenData);
           // 갱신된 토큰으로 이전 요청을 다시 시도
           return httpClient.request({
             ...error.config,
@@ -30,8 +29,13 @@ httpClient.interceptors.response.use(
         window.location.href = '/users/login';
         return Promise.reject(refreshError);
       }
+    } else if(error.response && error.response.status === 500){
+      window.location.href = baseURL+'/error/500/';
+  
     }
-    return Promise.reject(error);  // 401 이외의 오류는 그대로 반환
+    window.location.href=baseURL+'/error/404/'
+
+    return Promise.reject(error);
   }
 );
 

--- a/src/api/interceptor.js
+++ b/src/api/interceptor.js
@@ -13,7 +13,7 @@ httpClient.interceptors.response.use(
       // 401 응답일 때 토큰 갱신
       try {
         const newTokenData = await AutoRefreshToken();
-        // 갱신된 토큰으로만 업데이트
+        // 갱신된 토큰으로 업데이트
         if (newTokenData.access_token) {
           // 갱신된 토큰으로 이전 요청을 다시 시도
           return httpClient.request({
@@ -32,9 +32,10 @@ httpClient.interceptors.response.use(
     } else if(error.response && error.response.status === 500){
       window.location.href = baseURL+'/error/500/';
   
+    }else{
+      window.location.href=baseURL+'/error/404/'
     }
-    window.location.href=baseURL+'/error/404/'
-
+    
     return Promise.reject(error);
   }
 );

--- a/src/api/likes.js
+++ b/src/api/likes.js
@@ -2,12 +2,12 @@
 
 import axios from 'axios';
 const baseURL = import.meta.env.VITE_APP_API_KEY;
-
+import {httpClient} from './interceptor';
 
 const user = JSON.parse(localStorage.getItem("user"));
 const accessToken = user?.access_token || "";
 
-const axiosInstance = axios.create({
+const axiosInstance = httpClient.create({
   baseURL: baseURL,  // Replace with your API base URL
   headers: {
     Authorization: `Bearer ${accessToken}`,

--- a/src/api/recruits.js
+++ b/src/api/recruits.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 const baseURL = import.meta.env.VITE_APP_API_KEY;
-
+import {httpClient} from './interceptor';
 
 // Function to create a recruit post
 export const createRecruitsPost = async ({
@@ -27,7 +27,7 @@ export const createRecruitsPost = async ({
     }
 
 
-    const response = await axios.post(
+    const response = await httpClient.post(
        `${baseURL}/recruits/`,
       {
         team,
@@ -78,7 +78,7 @@ export const FetchRecruitsPost = async ({ page = 1, search = "", category = "", 
       const queryString = `?page=${page}&search=${search}&category=${category}&order_by=${order_by}&order=${order}&region=${region}`;
       const apiUrl = `${baseURL}/recruits/${queryString}`;
 
-      const res = await axios.get(apiUrl, {
+      const res = await httpClient.get(apiUrl, {
           headers: {
               Authorization: `Bearer ${accessToken}`,
           },
@@ -103,7 +103,7 @@ export const FetchRecruits = async ({id}) => {
           return null;
       }
  
-      const res = await axios.get(`${baseURL}/recruits/${id}/`, {
+      const res = await httpClient.get(`${baseURL}/recruits/${id}/`, {
           headers: {
               Authorization: `Bearer ${accessToken}`,
           },
@@ -129,7 +129,7 @@ export const FetchDelectRecruits = async ({id}) => {
           return null;
       }
  
-      const res = await axios.delete(`${baseURL}/recruits/${id}/`, {
+      const res = await httpClient.delete(`${baseURL}/recruits/${id}/`, {
           headers: {
               Authorization: `Bearer ${accessToken}`,
           },
@@ -154,7 +154,7 @@ export const FetchCheckRecruitsApplied = async ({ id }) => {
       return null;
     }
 
-    const res = await axios.get(`${baseURL}/recruits/${id}/apply/`, {
+    const res = await httpClient.get(`${baseURL}/recruits/${id}/apply/`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },

--- a/src/api/report.js
+++ b/src/api/report.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 const baseURL = import.meta.env.VITE_APP_API_KEY;
-
+import {httpClient} from './interceptor';
 
 
 const reportUrl = `${baseURL}/reports/`; // Replace with your actual API endpoint
@@ -15,7 +15,7 @@ export const submitReport = async ({ user_id, content }) => {
       return null;
     }
 
-    const response = await axios.post(
+    const response = await httpClient.post(
       reportUrl,
       {
         user_id: user_id,

--- a/src/components/Error/Error404Page.jsx
+++ b/src/components/Error/Error404Page.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Error404Page = () => {
+  return (
+    <div>
+      <h1>404 Not Found</h1>
+      <p>죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</p>
+      <p>다른 페이지를 찾아보시거나 홈페이지로 이동하세요.</p>
+    </div>
+  );
+};
+
+export default Error404Page;

--- a/src/components/Error/Error500Page.jsx
+++ b/src/components/Error/Error500Page.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Error500Page = () => {
+  return (
+    <div>
+      <h1>500 Internal Server Error</h1>
+      <p>죄송합니다. 서버에서 오류가 발생했습니다.</p>
+      <p>문제가 계속되면 관리자에게 문의하세요.</p>
+    </div>
+  );
+};
+
+export default Error500Page;


### PR DESCRIPTION
1. interceptor.js 의 커스텀 axios인 httpclient를 사용하면 이제 토큰이 만료되었을 때 재발급 후 재요청을 해줍니다.

2. 500에러의 페이지 핸들링을 추가했습니다.

3. 나머지 에러들은 모두 404로 반환되도록 했습니다.

그러나 애석하게도, 장고의 백엔드 설정이 더 먼저인 것인지 설정된 url을 error/404/로는 잘 리다이렉트해주지만
그 안의 html은 장고의 기본 에러 핸들링 페이지입니다.
아마 백엔드에서의 커스텀 설정도 필요한 것 같습니다.

제가 짧은 시간에 몇 번 테스트를 해본 후 문제가 없는 것 같다고 판단 했습니다만
혹시나 api요청에서 무언가 잘못된 거 같으시면 말씀해주세요.